### PR TITLE
feat: add greeting setting and use it in [zenesis_demo] shortcode

### DIFF
--- a/zenesis-demo.php
+++ b/zenesis-demo.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Plugin Name:       Zenesis Demo
- * Description:       Demo plugin for Qodo + PR review: adds [zenesis_demo name="World"] shortcode and a simple settings page.
- * Version:           0.1.0
+ * Description:       Demo plugin for Qodo + PR review: adds [zenesis_demo name="World"] shortcode, a simple settings page, and a greeting option on the General settings screen.
+ * Version:           0.2.0
  * Requires PHP:      8.1
  * Author:            Your Name
  * Text Domain:       zenesis-demo
@@ -23,6 +23,8 @@ add_action( 'init', 'zenesis_demo_register_shortcode' );
 /**
  * Shortcode callback.
  *
+ * Usage: [zenesis_demo name="World"]
+ *
  * @param array|string $atts Shortcode attributes.
  * @return string
  */
@@ -35,16 +37,17 @@ function zenesis_demo_shortcode( $atts = array() ): string {
 		'zenesis_demo'
 	);
 
-	$name = sanitize_text_field( $atts['name'] );
+	$name     = sanitize_text_field( $atts['name'] );
+	$greeting = get_option( 'zenesis_demo_greeting', 'Hello' );
 
 	return sprintf(
 		'<div class="zenesis-demo">%s</div>',
-		esc_html( "Hello, {$name}!" )
+		esc_html( $greeting . ', ' . $name . '!' )
 	);
 }
 
 /**
- * Admin menu.
+ * Admin menu (simple placeholder page).
  */
 function zenesis_demo_admin_menu(): void {
 	add_options_page(
@@ -58,7 +61,7 @@ function zenesis_demo_admin_menu(): void {
 add_action( 'admin_menu', 'zenesis_demo_admin_menu' );
 
 /**
- * Render admin page.
+ * Render admin page content.
  */
 function zenesis_demo_admin_page(): void {
 	if ( ! current_user_can( 'manage_options' ) ) {
@@ -66,4 +69,39 @@ function zenesis_demo_admin_page(): void {
 	}
 
 	echo '<div class="wrap"><h1>' . esc_html__( 'Zenesis Demo', 'zenesis-demo' ) . '</h1><p>' . esc_html__( 'Settings go here.', 'zenesis-demo' ) . '</p></div>';
+}
+
+/**
+ * Register a greeting setting and add a field to the General settings page.
+ */
+function zenesis_demo_register_setting(): void {
+	register_setting(
+		'general',
+		'zenesis_demo_greeting',
+		array(
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
+			'default'           => 'Hello',
+			'show_in_rest'      => false,
+		)
+	);
+
+	add_settings_field(
+		'zenesis_demo_greeting',
+		__( 'Zenesis Greeting', 'zenesis-demo' ),
+		'zenesis_demo_render_field',
+		'general',
+		'default'
+	);
+}
+add_action( 'admin_init', 'zenesis_demo_register_setting' );
+
+/**
+ * Render the greeting input field.
+ */
+function zenesis_demo_render_field(): void {
+	$value = get_option( 'zenesis_demo_greeting', 'Hello' );
+
+	echo '<input type="text" id="zenesis_demo_greeting" name="zenesis_demo_greeting" value="' . esc_attr( $value ) . '" class="regular-text" />';
+	echo '<p class="description">' . esc_html__( 'This greeting will be used by the [zenesis_demo] shortcode.', 'zenesis-demo' ) . '</p>';
 }


### PR DESCRIPTION
### **User description**
## Summary
- What does this change do?

## Checks
- [ ] Passes PHPCS (WPCS) and PHPStan
- [ ] No direct output without escaping (`esc_html`, `esc_attr`, etc.)
- [ ] Nonces + capability checks for admin actions
- [ ] I18n ready (`__()`, `_e()`, `esc_html__()`) with a text domain
- [ ] No deprecated WP APIs used

## Risk/QA
- Test notes or screenshots


___

### **PR Type**
Enhancement


___

### **Description**
- Add customizable greeting setting to General settings page

- Integrate greeting option with existing shortcode functionality

- Update plugin version and description


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["General Settings Page"] --> B["Zenesis Greeting Field"]
  B --> C["zenesis_demo_greeting Option"]
  C --> D["[zenesis_demo] Shortcode"]
  D --> E["Dynamic Greeting Output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zenesis-demo.php</strong><dd><code>Add greeting setting and shortcode integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

zenesis-demo.php

<ul><li>Add greeting setting registration with sanitization and default value<br> <li> Create settings field on General settings page with input renderer<br> <li> Integrate greeting option into shortcode output logic<br> <li> Update plugin version from 0.1.0 to 0.2.0 and description</ul>


</details>


  </td>
  <td><a href="https://github.com/3dubmedia/zenesis-demo/pull/2/files#diff-257c014608f08a16bc39004a490629e14fe495b5e882a5f83ea905dd5a488924">+44/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

